### PR TITLE
Fix build on Linux kernel 5.14

### DIFF
--- a/build/rhel7-x86_64/Makefile
+++ b/build/rhel7-x86_64/Makefile
@@ -3,7 +3,10 @@ K_VERS := $(wildcard /lib/modules/*/build)
 K_VERS := $(patsubst %/,%,$(dir $(K_VERS)))
 K_VERS := $(notdir $(K_VERS))
 
-all: $(K_VERS)
+LINUX_VERSION=rhel7-x86_64
+HEADERS:=../../$(LINUX_VERSION)
+
+all: $(K_VERS) $(HEADERS)
 
 
 evrma-objs	+= main_evrma.o mng-dev.o virt-dev.o rm.o packet-queue.o
@@ -13,7 +16,11 @@ evrma-objs	+= evr-sim.o event-list.o
 
 obj-m += evrma.o
 
-.PHONY: $(K_VERS)
+.PHONY: $(K_VERS) $(HEADERS)
+
+$(HEADERS):
+	mkdir -p $@/include
+	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $@/include/.
 
 $(K_VERS): OUTPUT_DIR=../../$@
 
@@ -23,6 +30,13 @@ $(K_VERS):
 	$(MAKE) module_load
 	chmod a+x module_*
 	$(MAKE) -C /lib/modules/$@/build M=$(PWD) modules
+	mkdir -p $(OUTPUT_DIR)/include/
+	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $(OUTPUT_DIR)/include/.
+	cp  *.ko $(OUTPUT_DIR)/.
+	cp module_* $(OUTPUT_DIR)/.
+
+install: OUTPUT_DIR=../../$(LINUX_VERSION)
+install:
 	mkdir -p $(OUTPUT_DIR)/include/
 	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $(OUTPUT_DIR)/include/.
 	cp  *.ko $(OUTPUT_DIR)/.

--- a/build/rhel9-x86_64/Makefile
+++ b/build/rhel9-x86_64/Makefile
@@ -1,0 +1,46 @@
+RHEL = rhel7
+K_VERS := $(wildcard /lib/modules/*/build/Makefile)
+$(info $(K_VERS))
+K_VERS := $(patsubst %/Makefile,%,$(K_VERS))
+K_VERS := $(patsubst %/,%,$(dir $(K_VERS)))
+$(info $(K_VERS))
+K_VERS := $(notdir $(K_VERS))
+$(info $(K_VERS))
+
+LINUX_VERSION=rhel9-x86_64
+
+all: $(K_VERS) ../../$(LINUX_VERSION)
+
+
+evrma-objs	+= main_evrma.o mng-dev.o virt-dev.o rm.o packet-queue.o
+evrma-objs	+= evr.o evr-irq-events.o evr-dbg.o
+evrma-objs	+= plx.o pci-evr.o
+evrma-objs	+= evr-sim.o event-list.o
+
+obj-m += evrma.o
+
+.PHONY: $(K_VERS) ../../$(LINUX_VERSION)
+
+$(K_VERS): OUTPUT_DIR=../../$@
+
+../../$(LINUX_VERSION):
+	mkdir -p $@/include
+	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $@/include/.
+
+$(K_VERS):
+	### copy the sources to make a directory for building
+	cp -r ../../src/* .
+	$(MAKE) module_load
+	chmod a+x module_*
+	$(MAKE) -C /lib/modules/$@/build M=$(PWD) modules
+	mkdir -p $(OUTPUT_DIR)/include/
+	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $(OUTPUT_DIR)/include/.
+	cp  *.ko $(OUTPUT_DIR)/.
+	cp module_* $(OUTPUT_DIR)/.
+
+module_load: original.module_load
+	sed 's/RHEL/$(RHEL)/' $< >$@
+
+clean:
+	rm -rf *.o *~ core .depend .*.cmd *.ko *.ko.unsigned *.mod.c .tmp_versions *.symvers  *.order *.c *.h module_* original.*
+

--- a/build/rhel9-x86_64/Makefile
+++ b/build/rhel9-x86_64/Makefile
@@ -38,6 +38,13 @@ $(K_VERS):
 	cp  *.ko $(OUTPUT_DIR)/.
 	cp module_* $(OUTPUT_DIR)/.
 
+install: OUTPUT_DIR=../../$(LINUX_VERSION)
+install:
+	mkdir -p $(OUTPUT_DIR)/include/
+	cp  linux-evrma.h linux-evr-regs.h linux-modac.h  $(OUTPUT_DIR)/include/.
+	cp  *.ko $(OUTPUT_DIR)/.
+	cp module_* $(OUTPUT_DIR)/.
+
 module_load: original.module_load
 	sed 's/RHEL/$(RHEL)/' $< >$@
 

--- a/src/mng-dev.c
+++ b/src/mng-dev.c
@@ -1791,8 +1791,13 @@ int modac_mngdev_init(dev_t dev_num, int count)
 	}
 	
 	mutex_init(&mngdev_table_mutex);
-	
-	modac_mngdev_class = class_create(THIS_MODULE, MODAC_MNG_CLASS_NAME);
+
+	modac_mngdev_class = 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,4)
+        class_create(MODAC_MNG_CLASS_NAME);
+#else
+        class_create(THIS_MODULE, MODAC_MNG_CLASS_NAME);
+#endif
 	if (IS_ERR(modac_mngdev_class)) {
 		printk(KERN_ERR "%s <init>: Failed to create device class!\n", MODAC_MNG_CLASS_NAME);
 		return PTR_ERR(modac_mngdev_class);

--- a/src/mng-dev.c
+++ b/src/mng-dev.c
@@ -585,9 +585,17 @@ static long mngdev_unlocked_ioctl(struct file *filp, unsigned int cmd, unsigned 
 	
 	/* Check access */
 	if (_IOC_DIR(cmd) & _IOC_READ) {
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		ret = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+    #else
+		ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+    #endif
 	} else if(_IOC_DIR(cmd) & _IOC_WRITE) {
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		ret = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+    #else
+		ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+    #endif
 	}
 	
 	if (ret) {

--- a/src/pci-evr.c
+++ b/src/pci-evr.c
@@ -860,7 +860,11 @@ static int evrma_pci_probe(struct pci_dev *pcidev, const struct pci_device_id *d
 			return -ENXIO;
 		}
 		
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
 		ev_device->emcor_io_ptr = ioremap_nocache(ev_device->emcor_start, ev_device->emcor_length);
+    #else
+		ev_device->emcor_io_ptr = ioremap(ev_device->emcor_start, ev_device->emcor_length);
+    #endif
 
 
 	} else 
@@ -887,7 +891,11 @@ static int evrma_pci_probe(struct pci_dev *pcidev, const struct pci_device_id *d
 	
 	current_clean = CLEAN_REQUEST_MEM;
 	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
 	ev_device->io_ptr = ioremap_nocache(ev_device->start, ev_device->length);
+#else
+	ev_device->io_ptr = ioremap(ev_device->start, ev_device->length);
+#endif
 	
 	if(ev_device->io_ptr == NULL) {
 		printk(KERN_ERR "evrma_pci_probe ioremap_nocache failed\n");

--- a/src/plx.c
+++ b/src/plx.c
@@ -7,6 +7,8 @@
 // may be copied, modified, propagated, or distributed except according to 
 // the terms contained in the LICENSE.txt file.
 //////////////////////////////////////////////////////////////////////////////
+#include <linux/version.h>
+
 #include "plx.h"
 
 #define PLX9030_INTCSR_LINTI1_ENA  0x0001 /* LINTi1 enable */
@@ -80,7 +82,11 @@ void evr_plx_init(struct evr_plx_data *plx, struct pci_dev *pcidev, int plx_bar,
 		
 		if (request_mem_region(plx->mrLC, plx->lenLC,
 					device_name) != NULL) {
+        #if LINUX_VERSION_CODE < KERNEL_VERSION(5,5,0)
 			plx->pLC = ioremap_nocache(local_conf_start, plx->lenLC);
+        #else
+			plx->pLC = ioremap(local_conf_start, plx->lenLC);
+        #endif
 		} else {
 			printk(KERN_ERR "PLX mem region request failed\n");
 			plx->pLC = NULL;

--- a/src/virt-dev.c
+++ b/src/virt-dev.c
@@ -922,7 +922,13 @@ int modac_vdev_init(dev_t dev_num, int count)
 	
 	mutex_init(&vdev_table_mutex);
 	
-	modac_vdev_class = class_create(THIS_MODULE, MODAC_VIRT_CLASS_NAME);
+	modac_vdev_class = 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9,4)
+        class_create(MODAC_VIRT_CLASS_NAME);
+#else
+        class_create(THIS_MODULE, MODAC_VIRT_CLASS_NAME);
+#endif
+
 	if (IS_ERR(modac_vdev_class)) {
 		printk(KERN_ERR "%s <init>: Failed to create device class!\n", MODAC_VIRT_CLASS_NAME);
 		return PTR_ERR(modac_vdev_class);

--- a/src/virt-dev.c
+++ b/src/virt-dev.c
@@ -238,9 +238,17 @@ static long vdev_unlocked_ioctl(struct file *filp, unsigned int cmd, unsigned lo
 	
 	/* Check access */
 	if (_IOC_DIR(cmd) & _IOC_READ) {
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		ret = !access_ok(VERIFY_WRITE, (void __user *)arg, _IOC_SIZE(cmd));
+    #else
+		ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+    #endif
 	} else if(_IOC_DIR(cmd) & _IOC_WRITE) {
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)
 		ret = !access_ok(VERIFY_READ, (void __user *)arg, _IOC_SIZE(cmd));
+    #else
+		ret = !access_ok((void __user *)arg, _IOC_SIZE(cmd));
+    #endif
 	}
 	
 	if (ret) {
@@ -557,7 +565,12 @@ static void vdev_vma_close(struct vm_area_struct *vma)
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,139)
-static int vdev_vma_fault(struct vm_fault *vmf)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,17,0)
+static int
+#else
+static vm_fault_t
+#endif
+vdev_vma_fault(struct vm_fault *vmf)
 #else
 static int vdev_vma_fault(struct vm_area_struct *vma, struct vm_fault *vmf)
 #endif


### PR DESCRIPTION
* The first parameter of `access_ok` was removed in kernel 5.0
* `READ_ONCE` was added in 3.18 and `ACCESS_ONCE` was deprecated in the same version. `ACCESS_ONCE` was then removed in 4.14. 
* `smp_read_barrier_depends` was removed in modern kernels. According to the docs, it was also a no-op on all platforms besides Alpha. I opted to replace it with a memory barrier to accomplish what the comment said.
* `ioremap_nocache` became `ioremap` in kernel 5.5.0 and the old `ioremap` behavior became `ioremap_cache`. The functions were basically swapped around.
* The return type of `vm_operations_struct.fault` was changed to `vm_fault_t` in kernel 4.17. This did not start breaking builds until a later kernel version though. 
* Kernel 6.4.0 removes the "module" parameter from `class_create` macro. RedHat decided to backport this change to their kernel 5.14.0 in RHEL 9.4, so we get some very strange `#if` logic to fix that.